### PR TITLE
feat: fliggle bumper page

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -12,20 +12,20 @@ class App extends StatelessWidget {
       theme: FliggleThemeData.lightTheme,
       darkTheme: FliggleThemeData.darkTheme,
       themeMode: ThemeMode.system, // 시스템 다크/라이트 따라감
-      home: MyHomePage(title: 'Fliggle'),
+      home: FliggleBumperPage(title: 'Fliggle'),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+class FliggleBumperPage extends StatefulWidget {
+  const FliggleBumperPage({super.key, required this.title});
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<FliggleBumperPage> createState() => _FliggleBumperPageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class _FliggleBumperPageState extends State<FliggleBumperPage> {
   int _counter = 0;
 
   void _incrementCounter() {

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 // import 'package:fliggle/app/view/auth/register/step_4.dart';
 import 'package:fliggle/app/view/core/design/fliggle_theme_data.dart';
+import 'package:fliggle/app/view/core/design/fliggle_colors.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -8,55 +9,31 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Fliggle',
       theme: FliggleThemeData.lightTheme,
       darkTheme: FliggleThemeData.darkTheme,
-      themeMode: ThemeMode.system, // 시스템 다크/라이트 따라감
-      home: FliggleBumperPage(title: 'Fliggle'),
+      themeMode: ThemeMode.system,
+      home: FliggleBumperPage(),
     );
   }
 }
 
-class FliggleBumperPage extends StatefulWidget {
-  const FliggleBumperPage({super.key, required this.title});
-  final String title;
-
-  @override
-  State<FliggleBumperPage> createState() => _FliggleBumperPageState();
-}
-
-class _FliggleBumperPageState extends State<FliggleBumperPage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
+class FliggleBumperPage extends StatelessWidget {
+  const FliggleBumperPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+      backgroundColor: FliggleColors.of(context).primary,
+      body: const Center(
+        child: Text(
+          'Fliggle',
+          style: TextStyle(
+            fontSize: 32,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/custom button.dart
+++ b/lib/custom button.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+const Color lightPrimaryColor = Color(0xFF6C98FF);
+const Color lightSecondaryColor = Color(0xFF87A9F7);
+
+const Color darkPrimaryColor = Color(0xFF497BEE);
+const Color darkSecondaryColor = Color(0xFF6C98FF);
+
+const Color disabledColor = Color(0xFF808080);
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Button Variants Demo',
+      themeMode: ThemeMode.system,
+      theme: ThemeData(
+        useMaterial3: true,
+        brightness: Brightness.light,
+        colorScheme: ColorScheme.light(
+          primary: lightPrimaryColor,
+          secondary: lightSecondaryColor,
+        ),
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: true,
+        brightness: Brightness.dark,
+        colorScheme: ColorScheme.dark(
+          primary: darkPrimaryColor,
+          secondary: darkSecondaryColor,
+        ),
+      ),
+      home: const ButtonDemoPage(),
+    );
+  }
+}
+
+class ButtonDemoPage extends StatelessWidget {
+  const ButtonDemoPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Button Variants")),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: const [
+            CustomButton(variant: 'surface', disabled: false),
+            SizedBox(height: 10),
+            CustomButton(variant: 'surface', disabled: true),
+            SizedBox(height: 10),
+            CustomButton(variant: 'outline', disabled: false),
+            SizedBox(height: 10),
+            CustomButton(variant: 'outline', disabled: true),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CustomButton extends StatelessWidget {
+  final String variant;
+  final bool disabled;
+
+  const CustomButton({
+    super.key,
+    required this.variant,
+    required this.disabled,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isOutline = variant == 'outline';
+    final colorScheme = Theme.of(context).colorScheme;
+    final Color primary = colorScheme.primary;
+
+    return SizedBox(
+      width: 120,
+      height: 34,
+      child: ElevatedButton(
+        onPressed: disabled ? null : () {},
+        style: ButtonStyle(
+          backgroundColor: WidgetStateProperty.resolveWith<Color>((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return isOutline ? Colors.white : disabledColor;
+            }
+            return isOutline ? Colors.white : primary;
+          }),
+          foregroundColor: WidgetStateProperty.resolveWith<Color>((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return isOutline ? disabledColor : Colors.white;
+            }
+            return isOutline ? primary : Colors.white;
+          }),
+          side: WidgetStateProperty.resolveWith<BorderSide>((states) {
+            if (!isOutline) return BorderSide.none;
+            return BorderSide(
+              color: states.contains(WidgetState.disabled)
+                  ? disabledColor
+                  : primary,
+            );
+          }),
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+          ),
+          elevation: WidgetStateProperty.all(0),
+          shape: WidgetStateProperty.all(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          ),
+        ),
+        child: const Text('Button', style: TextStyle(fontSize: 12)),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,10 +79,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
 sdks:
   dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/web/index.html
+++ b/web/index.html
@@ -29,7 +29,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>fliggle</title>
+  <title>Fliggle</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>


### PR DESCRIPTION
## PR 및 파일 구조 가이드라인
<details>
  <summary>PR 가이드라인 (필독!) - <a href="https://www.notion.so/route-five/Pull-Request-Guideline-2303696e576d80f9902cfc745aa78dec?source=copy_link">Notion의 PR Guideline</a> 참고</summary>
  
  - 커밋 가이드라인에 맞춰서 커밋을 해주시되, 한 PR에서 할당된 내용이 여러개이거나, 과정이 있을 경우 커밋을 **여러 개로 나누어 작성** 하시길 권장드립니다.
  - 만약 컴포넌트를 새로 만들거나, 디자인 관련 PR일 경우 스크린샷 혹은 작동 화면녹화를 `PR 설명`에 적어주세요.  
  - Coderabbit (AI)이 PR을 생성할 경우 리뷰합니다. 봇 코멘트는 참고만 하시고, `Resolve Conversation` 누르시면 됩니다.  
  - 각 프로젝트의 Lead 및 Sub-Lead (FE의 경우 @hoony6134, @rhseung) 검토자로 넣어주세요.  
  - 2개의 `approve`가 있어야 `main`으로 머지가 가능합니다. 만약 Lead 혹은 Sub-Lead의 승인을 받았다면 `@coderabbitai approve`를 댓글에 작성하면 토끼가 승인을 눌러줘서 2개가 됩니다.  
  - Flutter 프로젝트의 경우, 형식 및 위젯 테스트와 웹 버전 빌드 및 배포가 자동으로 진행됩니다. 테스트 및 웹 빌드/배포 절차를 거쳐 `status check`가 완료되어야 `approve`를 받고, `main`으로 머지될 수 있습니다. `flutter test`, `dart analyze`, `flutter build web --release` 명령을 실행하여 모두 정상적으로 작동되는지 확인해 보시길 권장드립니다.
</details>

<details>
  <summary>파일 구조 가이드라인 (필독!) - <a href="https://www.notion.so/route-five/File-Structure-Guideline-2313696e576d80d985bed3bc2214dbf9?source=copy_link">Notion의 File Structure Guideline</a> 참고</summary>
  
  - 본 프로젝트는 `MVVM` 구조를 따릅니다.
  - `lib/main.dart` 파일은 수정하지 말아 주세요.
  - 테스트 파일은 프로덕션 파일에 포함해서는 안됩니다.
  - 모든 파일 및 폴더는 `snake_case` 명명법을 따릅니다.
      - 옳은 예) `auth/register/step_4.dart`, `main.dart`
      - 나쁜 예) `Views/component.dart`, `step-4.dart`
  - 기능에 알맞는 폴더(view, service, model 등)에 파일을 추가해 주세요.
</details>

## 체크리스트
아래 체크리스트 내용을 확인하시고, 모든 항목에 체크해 주세요.
- [x] 파일 구조가 알맞게 작성되었습니다.
- [x] 커밋 가이드라인에 맞는 커밋 메시지를 작성하였습니다.
- [x] 작동 화면을 포함하지 않는 PR이거나, 아래 스크린샷/화면녹화를 업로드했습니다.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d17c407e-9515-4aa9-8f3f-be21c9c8e171" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 다양한 테마(라이트/다크)와 변형(서피스/아웃라인), 활성/비활성 상태를 지원하는 커스텀 버튼 데모 화면이 추가되었습니다.

* **스타일**
  * 앱 및 웹 타이틀이 "Fliggle"로 변경되었습니다.
  * 앱 첫 화면이 심플한 "Fliggle" 텍스트와 맞춤 배경색으로 구성된 화면으로 교체되었습니다.  
  * 앱 바와 플로팅 액션 버튼이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->